### PR TITLE
Small comma and batch_size placement

### DIFF
--- a/_posts/2018-07-30-attention-layer/attention-layer.Rmd
+++ b/_posts/2018-07-30-attention-layer/attention-layer.Rmd
@@ -40,7 +40,7 @@ The code in this post depends on the development versions of several of the Tens
 
 ```r
 devtools::install_github(c(
-  "rstudio/reticulate"
+  "rstudio/reticulate",
   "rstudio/tensorflow",
   "rstudio/keras",
   "rstudio/tfdatasets"
@@ -228,6 +228,8 @@ This section does not contain much code, but it shows an important technique: th
 Remember the olden times when we used to pass in hand-crafted generators to Keras models? With [tfdatasets](https://tensorflow.rstudio.com/tools/tfdatasets/articles/introduction.html), we can scalably feed data directly to the Keras `fit` function, having various preparatory actions being performed directly in native code. In our case, we will not be using `fit`, instead iterate directly over the tensors contained in the dataset. 
 
 ```{r}
+batch_size <- 32
+
 train_dataset <- 
   tensor_slices_dataset(keras_array(list(x_train, y_train)))  %>%
   dataset_shuffle(buffer_size = buffer_size) %>%
@@ -449,7 +451,6 @@ First, we need a few bookkeeping variables.
  
  
 ```{r}
-batch_size <- 32
 embedding_dim <- 64
 gru_units <- 256
 

--- a/_posts/2018-07-30-attention-layer/attention-layer.html
+++ b/_posts/2018-07-30-attention-layer/attention-layer.html
@@ -943,7 +943,7 @@
 <p>The code in this post depends on the development versions of several of the TensorFlow R packages. You can install these packages as follows:</p>
 <pre class="r"><code>
 devtools::install_github(c(
-  &quot;rstudio/reticulate&quot;
+  &quot;rstudio/reticulate&quot;,
   &quot;rstudio/tensorflow&quot;,
   &quot;rstudio/keras&quot;,
   &quot;rstudio/tfdatasets&quot;


### PR DESCRIPTION
When I was working my way through this (awesome) post I noticed two things. First, when I went to copy and paste the prereq packages I got a confusing error caused by a missing comma. 

Second in the code that gets run the variable `batch_size` is called before it is defined. I added it here where it is needed but I'm not sure it's the best way to do it as it's a tiny bit out of the blue. Let me know if you have another preference (e.g. functionalizing the dataset generation to take `batch_size` as an argument?).

Small note: I simply modified the html file by hand because of how long it takes to run the code. Hopefully that's not a no-no. 