### PR TITLE
Support publishing to r-bloggers

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -27,4 +27,8 @@ collections:
     share: [twitter, linkedin]
     subscribe: _subscribe.html
 output: distill::distill_article
-
+rss:
+  full_content: TRUE
+  categories:
+    - Packages/Releases
+    - TensorFlow/Keras


### PR DESCRIPTION
I think we should submit the AI blog to https://www.r-bloggers.com/ which requires enabling RSS full content, see https://github.com/rstudio/distill/pull/111